### PR TITLE
Update Config & Code

### DIFF
--- a/japanese-name/japanese-name.py
+++ b/japanese-name/japanese-name.py
@@ -1,15 +1,12 @@
-inp = input("Enter your name/word: ")
-name = inp.lower()
+inp=input()
+name=inp.lower()
 
-# Replacement rules and transliteration definitions
-double_letter = ("aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh", "ii", "jj", "kk", "ll", "mm", "nn", "oo", "pp", "qq", "rr", "ss", "tt", "uu", "vv", "ww", "xx", "yy", "zz")
-consonant = ("b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x", "z")
-exceptions = {
-    "wi": "bi", "vi": "bi", "ph": "f", "ds": "ts", "uc": "us", "l": "r", "ck": "k", "v": "w", "sch": "sh",
-    "ing": "in", "ny": "nu", "ä": "e", "ü": "u", "ö": "o", "q": "k", "j": "y", "c": "k", "tz": "z", "gh": "h", "th": "s"
-}
+double_letter = ("aa","bb","cc","dd","ee","ff","gg","hh","ii","jj","kk","ll","mm","nn","oo","pp","qq","rr","ss","tt","uu","vv","ww","xx","yy","zz")
+consonant = ("b","c","d","f","g","h","j","k","l","m","n","p","q","r","s","t","v","w","x","z")
+abc = ("a","b","c","d","e","f","g","h","j","i","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z")
+exc=("wi","vi","ph","ds","uc","l","ck","v","sch","ing","ny","ä","ü","ö","q","j","c","tz","gh","th")
+ins=("bi","bi","f","ts","us","r", "k", "w","sh","in","nu","e","u","o","k","y","k","z","h","s")
 
-# Katakana transliteration dictionary
 katakana_translation = {
     'a': 'ア', 'i': 'イ', 'u': 'ウ', 'e': 'エ', 'o': 'オ',
     'ka': 'カ', 'ki': 'キ', 'ku': 'ク', 'ke': 'ケ', 'ko': 'コ',
@@ -27,38 +24,99 @@ katakana_translation = {
     'ba': 'バ', 'bi': 'ビ', 'bu': 'ブ', 'be': 'ベ', 'bo': 'ボ',
     'pa': 'パ', 'pi': 'ピ', 'pu': 'プ', 'pe': 'ペ', 'po': 'ポ',
 }
+        
+for i in double_letter:
+   if i in name:
+        name=name.replace(i,i[0])
 
-# Process replacement rules for "Japanese pronunciation"
-for exception, insertion in exceptions.items():
-    name = name.replace(exception, insertion)
+end_exc = ("er","de","ke")
+end_ins = ("a","d","k")
+end_u_exc = ("h","n")
+for i in range (len(end_exc)):
+    if name.endswith(end_exc[i]):
+        name=name.replace(end_exc[i],end_ins[i])
+    
+for i in range(len(exc)):
+    if exc[i] in name:
+        name=name.replace(exc[i], ins[i])   
 
-# Final rules for consonants and endings
-if name and name[-1] in consonant:  # Check if the last character is a consonant
-    name += "u"
+def getPos(combination):
+    pos=(name.index(combination))+1
+    return pos
+  
+def y_combo_tester(y_combo,name):  
+    if y_combo in name:
+        pos=getPos(y_combo)
+        try:
+            y_combo_test=name[pos]+name[pos+1]
+        except:
+            y_combo_test=y_combo
+        return y_combo_test
 
-if name.endswith("r"):
-    name = name[:-1] + "ru"
+combination_exc = ("nb","sh","nd","nt","np","ts","ya","yu","yo")
+    
+    
+def y_combination():
+    global name
+    for i in abc:
+        y_combo = i+"y"
+        y_combo2 = "y"+i 
+        if y_combo_tester(y_combo,name) not in combination_exc:
+            while y_combo in name:
+                pos=getPos(y_combo)
+                name=name[:pos]+"i"+name[(pos+1):]
+        
+        elif y_combo2 not in combination_exc:
+            while y_combo2 in name:
+                pos=getPos(y_combo)
+                name=name[:(pos)-1]+"i"+name[pos:]             
+               
+y_combination()
+    
+def inserter(combination_1):
+    global name
+    for i in consonant:
+        combination = i+consonant[combination_1 ]
+        if combination not in combination_exc:
+            while combination in name:
+                if combination.endswith("h"):
+                    pos=getPos(combination)
+                    name=name[:pos]+name[(pos+1):]
+                elif combination.startswith("h"):
+                    pos=getPos(combination)
+                    name=name[:(pos-1)]+name[pos:]
+                else:
+                    pos=getPos(combination)
+                    name=name[:pos]+"u"+name[pos:]
+                    
+def combination_maker():
+    for combination_1 in range(0,(len(consonant ))):
+        inserter(combination_1)
+                    
+for i in range(0,2):
+    combination_maker()
+    
+if name.endswith(consonant):
+    if not name.endswith(end_u_exc):
+        name=name+"u"
 
-# Transliteration to Katakana
-katakana_name = ""
-original_name = name
+katakana_name = ''
+original_name = name  
 
 while len(name) > 0:
-    # Prioritize longer substrings first
-    for size in range(3, 0, -1):  # Check substrings of size 3, 2, 1
+    for size in range(2, 0, -1):
         current_slice = name[:size]
         if current_slice in katakana_translation:
             katakana_name += katakana_translation[current_slice]
             name = name[size:]
             break
     else:
-        # If no match, add the first character as it is
         katakana_name += name[0]
         name = name[1:]
 
-# Final output
-print(f'''
-Your original name/word: {inp}
-Japanese pronunciation: {original_name}
-Katakana translation: {katakana_name}
+print('''
+Your original name/word:''', inp, '''
+Japanese pronunciation:''', original_name, '''
+Katakana translation:''', katakana_name, '''
+
 ''')


### PR DESCRIPTION
Adjustments:

1. End-of-word consonant rule: If a name ends with a consonant such as r, then the vowel ending "u" is added to adjust to Japanese pronunciation.

2. Double transliteration (eg ck becomes k): Adjusted to be more natural following the Japanese pattern.

3. Removal of double consonants: Names with double letters such as "dd" or "nn" are simplified to one letter.

4. Katakana Translation: The transliteration system is better managed so that it can still produce names in Katakana correctly.